### PR TITLE
Add Minio object storage for OpenShift

### DIFF
--- a/openshift-services/logging/README.md
+++ b/openshift-services/logging/README.md
@@ -1,3 +1,7 @@
-## OpenShift Logging
+# OpenShift Logging Subsystem
 
 - After install you must configure indices in Kibana as documented here: <https://docs.openshift.com/container-platform/4.12/logging/cluster-logging-deploying.html#cluster-logging-visualizer-indices_cluster-logging-deploying>
+
+## Resources
+
+- https://docs.openshift.com/container-platform/4.12/logging/cluster-logging.html

--- a/openshift-services/logging/operand/clusterlogging.yaml
+++ b/openshift-services/logging/operand/clusterlogging.yaml
@@ -13,7 +13,11 @@ spec:
     type: elasticsearch
     retentionPolicy:
       application:
-        maxAge: 7d
+        maxAge: 3d
+      infra:
+        maxAge: 3d
+      audit:
+        maxAge: 3d
     elasticsearch:
       nodeCount: 3
       redundancyPolicy: SingleRedundancy

--- a/openshift-services/minio/README.md
+++ b/openshift-services/minio/README.md
@@ -1,0 +1,11 @@
+# Minio
+
+Deploy with `deploy.sh`.
+
+Wait 90-120s for automated TLS certificate generation to complete. Follow
+progress in logs for `minio-operator` pods in `openshift-operators` namespace
+
+## Resources
+
+- https://github.com/minio/operator
+- https://github.com/minio/operator/blob/master/pkg/apis/minio.min.io/v2/types.go

--- a/openshift-services/minio/deploy.sh
+++ b/openshift-services/minio/deploy.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+root_dir=$(cd ${this_dir}/../.. && pwd)
+if [[ -e "${root_dir}/.env" ]]; then source ${root_dir}/.env; fi
+source ${root_dir}/lib/kubernetes.sh
+
+tenant_namespace=minio-tenant
+
+apply_kustomize_dir ${this_dir}/operator
+await_resource_ready 'minio\.min\.io'
+
+ensure_namespace ${tenant_namespace}
+oc config set-context --current --namespace ${tenant_namespace}
+oc adm policy add-scc-to-user --serviceaccount default nonroot
+
+apply_kustomize_dir ${this_dir}/storage

--- a/openshift-services/minio/operator/kustomization.yaml
+++ b/openshift-services/minio/operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+- subscription.yaml

--- a/openshift-services/minio/operator/subscription.yaml
+++ b/openshift-services/minio/operator/subscription.yaml
@@ -2,10 +2,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-    name: odf-operator
+    name: minio-operator
 spec:
-    name: odf-operator
-    source: redhat-operators
+    name: minio-operator
+    source: certified-operators
     sourceNamespace: openshift-marketplace
-    channel: stable-4.12
+    channel: stable
     installPlanApproval: Automatic

--- a/openshift-services/minio/storage/kustomization.yaml
+++ b/openshift-services/minio/storage/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: minio-tenant
+resources:
+- namespace.yaml
+- minio-tenant-config-secret.yaml
+- minio-root-creds-secret.yaml
+- minio-user-secret.yaml
+- tenant.yaml

--- a/openshift-services/minio/storage/minio-root-creds-secret.yaml
+++ b/openshift-services/minio/storage/minio-root-creds-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-root-creds
+type: Opaque
+stringData:
+  accesskey: UziH93R6TtIV6c0H
+  secretkey: tmFeAFmA94I0E1yXHHS9Wq6BKb2pXNli

--- a/openshift-services/minio/storage/minio-tenant-config-secret.yaml
+++ b/openshift-services/minio/storage/minio-tenant-config-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-tenant-config
+type: Opaque
+stringData:
+  config.env: |-
+    export MINIO_ROOT_USER="minio"
+    export MINIO_ROOT_PASSWORD="minio123"
+    export MINIO_STORAGE_CLASS_STANDARD="EC:2"
+    export MINIO_BROWSER="on"

--- a/openshift-services/minio/storage/minio-user-secret.yaml
+++ b/openshift-services/minio/storage/minio-user-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-user
+type: Opaque
+stringData:
+  CONSOLE_ACCESS_KEY: 8tz9HO3WtmQBLil8
+  CONSOLE_SECRET_KEY: vJwdnsXtS3NmuPvJVplgPBvP2BZlcFaV

--- a/openshift-services/minio/storage/namespace.yaml
+++ b/openshift-services/minio/storage/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: minio-tenant

--- a/openshift-services/minio/storage/tenant.yaml
+++ b/openshift-services/minio/storage/tenant.yaml
@@ -1,0 +1,50 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: tenant0
+  labels:
+    app: minio
+spec:
+  serviceAccountName: default
+  credsSecret:
+    name: minio-root-creds
+  users:
+    - name: minio-user
+  configuration:
+    name: minio-tenant-config
+  requestAutoCert: true
+  features:
+    bucketDNS: false
+    domains: {}
+  podManagementPolicy: Parallel
+  env: []
+  pools:
+    - servers: 4
+      name: pool-0
+      volumesPerServer: 4
+      nodeSelector: {}
+      tolerations: []
+      affinity:
+        nodeAffinity: {}
+        podAffinity: {}
+        podAntiAffinity: {}
+      resources: {}
+      volumeClaimTemplate:
+        apiVersion: v1
+        kind: persistentvolumeclaims
+        metadata: {}
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Gi
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        fsGroup: 1000
+      containerSecurityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true

--- a/openshift-services/odf/README.md
+++ b/openshift-services/odf/README.md
@@ -17,3 +17,5 @@ oc label nodes --all "cluster.ocs.openshift.io/openshift-storage="
 - https://www.redhat.com/sysadmin/finding-block-and-file1
 - https://red-hat-storage.github.io/ocs-training/training/index.html
 - https://github.com/rook/rook/blob/master/design/ceph/resource-constraints.md
+- https://github.com/red-hat-storage/odf-operator
+- https://github.com/red-hat-storage/ocs-operator


### PR DESCRIPTION
This is to support Lokistack resources which require object (S3) storage.

I don't always want the weightiness of ODF so trying Minio as an option.

See #9