### PR TITLE
Add Noobaa (for QuayRegistry)

### DIFF
--- a/openshift-services/noobaa/README.md
+++ b/openshift-services/noobaa/README.md
@@ -1,0 +1,10 @@
+## Noobaa
+
+Noobaa provides ObjectBucketClaim and ObjectBucket resource types.
+
+ObjectBucketClaims are required by QuayRegistry resource type.
+
+## Usage
+
+1. Install or update the `noobaa` CLI by using commands in `[install.sh](./install.sh)`
+1. Run `deploy.sh`, which will install the noobaa operator, create a PV-backed BackingStore and override the default BucketClass to use it.

--- a/openshift-services/noobaa/bucketclass/backingstore.yaml
+++ b/openshift-services/noobaa/bucketclass/backingstore.yaml
@@ -1,0 +1,15 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  name: noobaa-pv
+  namespace: noobaa
+  finalizers:
+  - noobaa.io/finalizer
+spec:
+  pvPool:
+    numVolumes: 10
+    resources:
+      requests:
+        storage: 40Gi
+    storageClass: gp3-csi
+  type: pv-pool

--- a/openshift-services/noobaa/bucketclass/bucketclass.yaml
+++ b/openshift-services/noobaa/bucketclass/bucketclass.yaml
@@ -1,0 +1,13 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: noobaa-default-bucket-class
+  namespace: noobaa
+  labels:
+    app: noobaa
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - noobaa-pv
+      placement: Spread

--- a/openshift-services/noobaa/bucketclass/kustomization.yaml
+++ b/openshift-services/noobaa/bucketclass/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: noobaa
+resources:
+- backingstore.yaml
+- bucketclass.yaml

--- a/openshift-services/noobaa/deploy.sh
+++ b/openshift-services/noobaa/deploy.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+this_dir=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+root_dir=$(cd ${this_dir}/../.. && pwd)
+if [[ -e "${root_dir}/.env" ]]; then source ${root_dir}/.env; fi
+source ${root_dir}/lib/kubernetes.sh
+
+ensure_namespace noobaa true
+noobaa install
+await_resource_ready noobaa
+
+kustomize build ${this_dir}/bucketclass | oc apply -f -

--- a/openshift-services/noobaa/install.sh
+++ b/openshift-services/noobaa/install.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+OS=linux
+VERSION=$(curl -s https://api.github.com/repos/noobaa/noobaa-operator/releases/latest | jq -r '.name')
+curl -LO https://github.com/noobaa/noobaa-operator/releases/download/$VERSION/noobaa-$OS-$VERSION
+chmod +x noobaa-$OS-$VERSION
+
+sudo mv noobaa-$OS-$VERSION /usr/local/bin/noobaa
+noobaa version

--- a/openshift-services/quay/README.md
+++ b/openshift-services/quay/README.md
@@ -1,4 +1,15 @@
 # Quay
 
+Install QuayRegistry operator and custom resource type, then deploy a registry.
+
+Requires ObjectBucketClaim resource type in cluster (via [Noobaa](../noobaa/)).
+
+## Notes
+
+- Use the special "config editor" route to update Quay config in a web form.
+- For "super user" access in the web portal, create a new account via the main Quay route/site and add that account as a "super user" in Quay config.
+- TODO: automate creating a user account and adding it as a super user.
+
+## Resources
+
 - https://github.com/quay/quay-operator
-- https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/index

--- a/openshift-services/quay/operator/subscription.yaml
+++ b/openshift-services/quay/operator/subscription.yaml
@@ -7,5 +7,5 @@ spec:
     name: quay-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace
-    channel: stable-3.7
+    channel: stable-3.8
     installPlanApproval: Automatic

--- a/openshift-services/quay/registry/registry.yaml
+++ b/openshift-services/quay/registry/registry.yaml
@@ -12,8 +12,6 @@ spec:
         managed: true
       - kind: redis
         managed: true
-      - kind: horizontalpodautoscaler
-        managed: true
       - kind: route
         managed: true
       - kind: mirror
@@ -26,3 +24,5 @@ spec:
         managed: true
       - kind: clairpostgres
         managed: true
+      - kind: horizontalpodautoscaler
+        managed: false


### PR DESCRIPTION
Add support for Noobaa independently of ODF (Rook/Ceph).
Required for QuayRegistry resource, which depends on `ObjectBucketClaim`